### PR TITLE
vectorised implementation of convert_snpeff_annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 .DS_Store
 __pycache__
+*.lprof


### PR DESCRIPTION
## What?
Reworked convert_snpeff_annotation function to operate in a vectorised manner over entire df, rather than row by row with an apply()

## Why?
When handling large numbers of VCF files, the non-vectorised convert_snpeff_annotation function became an unnecessarily rate limiting step, see #1 

## How?
Function now operates over entire dataframe rather than row by row, but logic is essentially the same. 

## Anything Else?
Vectorised implementations of functions should be considered for future modules within the SPEAR annotation system. 

